### PR TITLE
Copy the mapping table items on click

### DIFF
--- a/src/main/java/net/fabricmc/mappingpoet/jd/MappingTaglet.java
+++ b/src/main/java/net/fabricmc/mappingpoet/jd/MappingTaglet.java
@@ -82,7 +82,7 @@ public final class MappingTaglet implements Taglet {
 			builder.append(String.format("<td align=\"center\">%s</td>\n", escaped(ans[0])));
 			final int bound = typeDecl ? 2 : 3;
 			for (int i = 1; i < bound; i++) {
-				builder.append(String.format("<td align=\"center\"><span class=\"copyable\" title=\"Click to copy\"><code class=\"literal\">%s</code></span></td>\n", escaped(ans[i])));
+				builder.append(String.format("<td align=\"center\"><span class=\"copyable\"><code class=\"literal\">%s</code></span></td>\n", escaped(ans[i])));
 			}
 			builder.append("</tr>\n");
 		}

--- a/src/main/java/net/fabricmc/mappingpoet/jd/MappingTaglet.java
+++ b/src/main/java/net/fabricmc/mappingpoet/jd/MappingTaglet.java
@@ -82,7 +82,7 @@ public final class MappingTaglet implements Taglet {
 			builder.append(String.format("<td align=\"center\">%s</td>\n", escaped(ans[0])));
 			final int bound = typeDecl ? 2 : 3;
 			for (int i = 1; i < bound; i++) {
-				builder.append(String.format("<td align=\"center\"><span name=\"copyable\"><code class=\"literal\">%s</code></span></td>\n", escaped(ans[i])));
+				builder.append(String.format("<td align=\"center\"><span class=\"copyable\" title=\"Click to copy\"><code class=\"literal\">%s</code></span></td>\n", escaped(ans[i])));
 			}
 			builder.append("</tr>\n");
 		}
@@ -90,7 +90,7 @@ public final class MappingTaglet implements Taglet {
 		builder.append("</tbody>\n");
 		builder.append("</table>\n");
 		builder.append("<script>\n");
-		builder.append(JS_CONTENT); // todo this doesn't work. Need to make it copy on click
+		builder.append(JS_CONTENT);
 		builder.append("</script>\n");
 		return builder.toString();
 	}

--- a/src/main/resources/copy_on_click.js
+++ b/src/main/resources/copy_on_click.js
@@ -2,13 +2,15 @@ document.onreadystatechange = function() {
   if(document.readyState == "complete") {
     const items = document.querySelectorAll(".copyable");
     items.forEach(item => {
+      item.title = "Click to copy";
+      item.style["cursor"] = "pointer";
       item.onclick = function() {
         var range = document.createRange();
   	    range.selectNode(item);
   	    window.getSelection().addRange(range);
-        document.execCommand('copy');
+        document.execCommand("copy");
         window.getSelection().removeRange(range);
-        console.log('Copyed to clipboard');
+        console.log("Copied to clipboard");
       };
     });
   }

--- a/src/main/resources/copy_on_click.js
+++ b/src/main/resources/copy_on_click.js
@@ -1,19 +1,15 @@
-/* https://stackoverflow.com/a/45071478 */
-/* doesn't work yet */
-const items = document.querySelectorAll("span");
-
-items.forEach(item => {
-  item.onclick = function() {
-    item.select();
-    item.setSelectionRange(0, 1048576);
-    document.execCommand("copy");
-  };
-});
-
-items.forEach(item => {
-  item.addEventListener("copy", function(event) {
-    event.preventDefault();
-    event.clipboardData.setData("text/plain", span.textContent);
-    console.log(event.clipboardData.getData("text"));
-  })
-});
+document.onreadystatechange = function() {
+  if(document.readyState == "complete") {
+    const items = document.querySelectorAll(".copyable");
+    items.forEach(item => {
+      item.onclick = function() {
+        var range = document.createRange();
+  	    range.selectNode(item);
+  	    window.getSelection().addRange(range);
+        document.execCommand('copy');
+        window.getSelection().removeRange(range);
+        console.log('Copyed to clipboard');
+      };
+    });
+  }
+};


### PR DESCRIPTION
This PR fixes #8.

First of all, I still don't know how to make this tool work, I've tested this on the javadocs zip in one of the latest PRs (#6).

This PR implements the required code to copy the `copyable` field of the mapping table when clicking. To do so, it sets the listener (could add instead, see below) to the `readyStateChange` event of the document to loop through every item with the `copyable` class. In those, it sets the `click` event to be creating a range with it, adding that range to the current selection, copying the current selection, and removing the added selection.

In order to easily find the items, they have now added a `copyable` class instead of name (name would be `[name=...]` in selector). It also adds a small `title` tag that shows `Click to copy` when hovering. ~Something that also could be added would be a `cursor:pointer` style, to make it more obvious.~ Added

As mentioned in #8, it has small problems. However, those are very unlikely to happen (second) or to harm (first).

The reason this code does not _add_ an event listener but _sets_ it (old function that only supports one listener, probably kept for compatibility) is because the script is added to the javadoc multiple times every page, which would mean that the code would also be run multiple times, and this specific one would actually throw an error after the first one since constants can't be modified, and therefore only first table would have the event.

It would be better to instead add the script once per page (somehow, again I don't know how this works or even get it running, so I can't do it). It's not really necessary to change it to add instead of setting, since nothing else in the page is using that field.