### PR TITLE
Make mappings table match javadoc style and remove deprecated attributes

### DIFF
--- a/src/main/java/net/fabricmc/mappingpoet/jd/MappingTaglet.java
+++ b/src/main/java/net/fabricmc/mappingpoet/jd/MappingTaglet.java
@@ -63,14 +63,13 @@ public final class MappingTaglet implements Taglet {
 	public String toString(List<? extends DocTree> tags, Element element) {
 		boolean typeDecl = element instanceof TypeElement; // means it's a class, itf, enum, etc.
 		StringBuilder builder = new StringBuilder();
-		builder.append("<p class=\"title\" align=\"center\"><b>Mapping data</b></p>\n");
-		builder.append("<table class=\"table\" summary=\"Mapping data\" border=\"1\" align=\"center\">\n");
-		builder.append("<colgroup><col><col><col></colgroup>\n");
+		builder.append("<h3 class=\"title\">Mapping data</h3>\n");
+		builder.append("<table class=\"memberSummary\" summary=\"Mapping data\">\n");
 		builder.append("<thead>\n");
-		builder.append("<th align=\"center\">Namespace</th>\n");
-		builder.append("<th align=\"center\">Name</th>\n");
+		builder.append("<th class=\"colFirst\">Namespace</th>\n");
+		builder.append("<th class=\""+(typeDecl ? "colSecond" : "colLast")+"\">Name</th>\n");
 		if (!typeDecl) {
-			builder.append("<th align=\"center\">Mixin selector</th>\n");
+			builder.append("<th class=\"colLast\">Mixin selector</th>\n");
 		}
 		builder.append("</thead>\n");
 		builder.append("<tbody>\n");
@@ -79,10 +78,10 @@ public final class MappingTaglet implements Taglet {
 			String body = ((UnknownBlockTagTree) each).getContent().stream().map(t -> ((LiteralTree) t).getBody().getBody()).collect(Collectors.joining());
 			String[] ans = body.split(":", 3);
 			builder.append("<tr>\n");
-			builder.append(String.format("<td align=\"center\">%s</td>\n", escaped(ans[0])));
+			builder.append(String.format("<td class=\"colFirst\">%s</td>\n", escaped(ans[0])));
 			final int bound = typeDecl ? 2 : 3;
 			for (int i = 1; i < bound; i++) {
-				builder.append(String.format("<td align=\"center\"><span name=\"copyable\"><code class=\"literal\">%s</code></span></td>\n", escaped(ans[i])));
+				builder.append(String.format("<td class=\"colSecond\"><span name=\"copyable\"><code>%s</code></span></td>\n", escaped(ans[i])));
 			}
 			builder.append("</tr>\n");
 		}

--- a/src/main/java/net/fabricmc/mappingpoet/jd/MappingTaglet.java
+++ b/src/main/java/net/fabricmc/mappingpoet/jd/MappingTaglet.java
@@ -67,7 +67,7 @@ public final class MappingTaglet implements Taglet {
 		builder.append("<table class=\"memberSummary\" summary=\"Mapping data\">\n");
 		builder.append("<thead>\n");
 		builder.append("<th class=\"colFirst\">Namespace</th>\n");
-		builder.append("<th class=\""+(typeDecl ? "colSecond" : "colLast")+"\">Name</th>\n");
+		builder.append("<th class=\"" + (typeDecl ? "colSecond" : "colLast") + "\">Name</th>\n");
 		if (!typeDecl) {
 			builder.append("<th class=\"colLast\">Mixin selector</th>\n");
 		}


### PR DESCRIPTION
This PR makes the Mappings Data table style match the rest of the javadoc, and also removes unused or deprecated attributes.

Preview:

![imagen](https://user-images.githubusercontent.com/17107132/103090892-b40bb380-45f2-11eb-9f71-623f9d681d4d.png)

![imagen](https://user-images.githubusercontent.com/17107132/103090913-cede2800-45f2-11eb-806a-e2c5e12f5ef8.png)

Preview HTML: [AliasedBlockItem.zip](https://github.com/FabricMC/MappingPoet/files/5739691/AliasedBlockItem.zip) (made by hand and Find and Replace) (note: this preview HTML should be placed in an existing doc at `net/minecraft/item` in order to work) (note: this preview HTML also contains the click action from #9).

Uses the classes declared by javadoc itself in order to get those styles.

The removed elements are:

- All the `align="center"` attributes. It's deprecated since long time ago. If wanted, use `style="text-align: center"` instead (or add it to a stylesheet matching that class)
- The `border="1"` attribute. It's also deprecated
- The `<colgroup>` tag. It is unused in this case
- The `class="literal"` from the `<code>` elements. There are no styles nor scripted actions declared for that class.

Things that could be better: In order to match what javadoc does, the last `<td>` element (L84) should have the `colLast` class instead of `colSecond` for consistency, although both classes (at least currently) have the same styling applied.

Please test this by actually running the program, I've still not been able to generate mappings with it.

This conflicts with #9, since this PR changes the line where the `name="copyable"` exists. Simple to fix though.